### PR TITLE
Migrations: Make Table to TableBuilder & Create new Table Obj & implement exists()/delete() into Table Object.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 experiments
 db.sqlite3
+test.zsh

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -1,6 +1,7 @@
 import { QueryBuilder } from "../querybuilder.ts";
 import { Model } from "../model.ts";
 import { SupportedDatabaseType } from "../connect.ts";
+import { TableBuilder } from "../table.ts";
 
 export interface QueryOptions {
   getLastInsertedId?: boolean;
@@ -80,6 +81,15 @@ export abstract class Adapter {
    */
   public getModels(): Array<typeof Model> {
     return this.models;
+  }
+
+  /**
+   * Register a model
+   *
+   * @param model The model to be registered
+   */
+  public tableBuilder(tableName: string): TableBuilder {
+    return new TableBuilder(tableName, this);
   }
 
   /**

--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -1,7 +1,7 @@
 import { QueryBuilder } from "../querybuilder.ts";
 import { Model } from "../model.ts";
 import { SupportedDatabaseType } from "../connect.ts";
-import { TableBuilder } from "../table.ts";
+import { Table } from "../table.ts";
 
 export interface QueryOptions {
   getLastInsertedId?: boolean;
@@ -88,8 +88,8 @@ export abstract class Adapter {
    *
    * @param model The model to be registered
    */
-  public tableBuilder(tableName: string): TableBuilder {
-    return new TableBuilder(tableName, this);
+  public table(tableName: string): Table {
+    return new Table(tableName, this);
   }
 
   /**

--- a/src/adapters/adapter_test.ts
+++ b/src/adapters/adapter_test.ts
@@ -2,7 +2,7 @@ import { Model, FieldType } from "../model.ts";
 import { testDB } from "../testutils.ts";
 import { assertEquals } from "../../testdeps.ts";
 import { QueryBuilder } from "../querybuilder.ts";
-import { TableBuilder } from "../table.ts";
+import { Table } from "../table.ts";
 
 class User extends Model {
   static tableName = "users";
@@ -93,7 +93,7 @@ testDB(
 testDB(
   "BaseAdapter: `tableBuilder` should contains actual table builder",
   (client) => {
-    const query = client.tableBuilder("users");
-    assertEquals(query instanceof TableBuilder, true);
+    const query = client.table("users");
+    assertEquals(query instanceof Table, true);
   },
 );

--- a/src/adapters/adapter_test.ts
+++ b/src/adapters/adapter_test.ts
@@ -2,6 +2,7 @@ import { Model, FieldType } from "../model.ts";
 import { testDB } from "../testutils.ts";
 import { assertEquals } from "../../testdeps.ts";
 import { QueryBuilder } from "../querybuilder.ts";
+import { TableBuilder } from "../table.ts";
 
 class User extends Model {
   static tableName = "users";
@@ -86,5 +87,13 @@ testDB(
   (client) => {
     const query = client.queryBuilder("users");
     assertEquals(query instanceof QueryBuilder, true);
+  },
+);
+
+testDB(
+  "BaseAdapter: `tableBuilder` should contains actual table builder",
+  (client) => {
+    const query = client.tableBuilder("users");
+    assertEquals(query instanceof TableBuilder, true);
   },
 );

--- a/src/table.ts
+++ b/src/table.ts
@@ -196,29 +196,25 @@ export class TableInfo {
 
     switch (this.adapter.type) {
       case "sqlite":
-        return (await (await this.adapter.query(
+        const sqliteQuery = await this.adapter.query(
           `SELECT name FROM sqlite_master WHERE type='table' AND name='${this.tableName}'`,
-        )).records.length) == 1;
+        );
+        return sqliteQuery.records.length === 1;
       case "postgres":
-        var fromDB = (await (await this.adapter.query(
-          `SELECT EXISTS (
-              SELECT FROM pg_tables
-              WHERE    tablename  = '${this.tableName}'
-              )`,
-        )));
-        if (!!fromDB.records && !!fromDB.records[0]) {
-          let result = fromDB.records[0] as any;
+        const postgresQuery = await this.adapter.query(
+          `SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = '${this.tableName}')`,
+        );
+        if (postgresQuery.records[0]) {
+          let result = postgresQuery.records[0] as any;
           return result.exists;
-        } else return false;
-        break;
+        } else {
+          return false;
+        }
       case "mysql":
-        return (await (await this.adapter.query(
-          `SELECT * 
-          FROM information_schema.tables
-              WHERE table_name = '${this.tableName}'
-          LIMIT 1`,
-        )).records.length) == 1;
-        break;
+        const mysqlQuery = await this.adapter.query(
+          `SELECT * FROM information_schema.tables WHERE table_name = '${this.tableName}' LIMIT 1`,
+        );
+        return mysqlQuery.records.length === 1;
       default:
         return false;
     }

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,6 +1,5 @@
 import { COLUMN_TYPES } from "./constants.ts";
 import { Adapter, QueryResult, QueryOptions } from "./adapters/adapter.ts";
-import { SqliteAdapter } from "./adapters/sqlite.ts";
 
 interface ColumnDefinition {
   type: keyof typeof COLUMN_TYPES;

--- a/src/table.ts
+++ b/src/table.ts
@@ -16,6 +16,9 @@ interface TableOptions {
   createIfNotExists?: boolean;
 }
 
+/**
+ * Handles a Table, create, modify or get info about the table.
+ */
 export class Table {
   constructor(
     /** Table name on the database */
@@ -34,7 +37,7 @@ export class Table {
   }
 
   /**
-   * Delete a table
+   * Delete this table.
    */
   async delete() {
     if (!this.adapter) {
@@ -48,16 +51,17 @@ export class Table {
   }
 
   /**
-   * Modify a table
+   * Modify a table(add rows or constraints). NOT IMPLEMENTED YET.
    */
   modify() {
     throw new Error("Not implementet yet");
   }
-
+  /** Will give tableinfos(Columnnames, Row Count or Key Infos [...]) NOT IMPLEMENTED YET. */
   info() {
     return new TableInfo(this.tableName, this.adapter);
   }
 
+  /** Checks if this Table exists. */
   exists() {
     return new TableInfo(this.tableName, this.adapter).exists();
   }
@@ -184,6 +188,7 @@ export class TableInfo {
     this.options = Object.assign({}, { createIfNotExists: false }, options);
   }
 
+  /** Checks if this Table exists. */
   async exists(): Promise<boolean> {
     if (!this.adapter) {
       throw new Error("Cannot run query, adapter is not provided!");

--- a/src/table_test.ts
+++ b/src/table_test.ts
@@ -1,5 +1,6 @@
 import { TableBuilder } from "./table.ts";
 import { assertEquals } from "../testdeps.ts";
+import { testDB } from "./testutils.ts";
 
 Deno.test("Table: mysql", () => {
   const table = new TableBuilder("users", undefined, { dialect: "mysql" })
@@ -38,4 +39,13 @@ Deno.test("Table: postgres", () => {
     table.toSQL(),
     "create table users (id serial primary key, name varchar);",
   );
+});
+
+testDB("Model: insert", async (client) => {
+  client.tableBuilder("sigma")
+    .addField(
+      { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
+    )
+    .addField({ type: "varchar", name: "name" })
+    .execute();
 });

--- a/src/table_test.ts
+++ b/src/table_test.ts
@@ -1,11 +1,12 @@
-import { Table } from "./table.ts";
+import { TableBuilder } from "./table.ts";
 import { assertEquals } from "../testdeps.ts";
 
 Deno.test("Table: mysql", () => {
-  const table = new Table("users", [
-    { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
-    { type: "varchar", name: "name" },
-  ], { dialect: "mysql" });
+  const table = new TableBuilder("users", undefined, { dialect: "mysql" })
+    .addField(
+      { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
+    )
+    .addField({ type: "varchar", name: "name" });
 
   assertEquals(
     table.toSQL(),
@@ -14,10 +15,11 @@ Deno.test("Table: mysql", () => {
 });
 
 Deno.test("Table: sqlite", () => {
-  const table = new Table("users", [
-    { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
-    { type: "varchar", name: "name" },
-  ], { dialect: "sqlite" });
+  const table = new TableBuilder("users", undefined, { dialect: "sqlite" })
+    .addField(
+      { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
+    )
+    .addField({ type: "varchar", name: "name" });
 
   assertEquals(
     table.toSQL(),
@@ -26,10 +28,11 @@ Deno.test("Table: sqlite", () => {
 });
 
 Deno.test("Table: postgres", () => {
-  const table = new Table("users", [
-    { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
-    { type: "varchar", name: "name" },
-  ], { dialect: "postgres" });
+  const table = new TableBuilder("users", undefined, { dialect: "postgres" })
+    .addField(
+      { type: "increments", name: "id", primaryKey: true, autoIncrement: true },
+    )
+    .addField({ type: "varchar", name: "name" });
 
   assertEquals(
     table.toSQL(),

--- a/src/table_test.ts
+++ b/src/table_test.ts
@@ -22,7 +22,6 @@ Deno.test("Table: sqlite", () => {
     )
     .addField({ type: "varchar", name: "name" });
 
-  console.log("SQLite: " + table.toSQL());
   assertEquals(
     table.toSQL(),
     "create table users (id integer primary key autoincrement, name varchar(2048));",
@@ -36,7 +35,6 @@ Deno.test("Table: postgres", () => {
     )
     .addField({ type: "varchar", name: "name" });
 
-  console.log("POSTGRES: " + table.toSQL());
   assertEquals(
     table.toSQL(),
     "create table users (id serial primary key, name varchar(2048));",
@@ -56,21 +54,6 @@ testDB("Table: create and check for existence", async (client) => {
   assertEquals(
     await tablehandler.exists(),
     false,
-  );
-
-  // Spill the beans
-  console.log(
-    client.type + " : " + await tablehandler.create()
-      .addField(
-        {
-          type: "increments",
-          name: "id",
-          primaryKey: true,
-          autoIncrement: true,
-        },
-      )
-      .addField({ type: "varchar", name: "name" })
-      .toSQL(),
   );
 
   // Now we create the table again

--- a/test.ts
+++ b/test.ts
@@ -2,6 +2,7 @@
 
 import "./src/connect_test.ts";
 import "./src/querybuilder_test.ts";
+import "./src/table_test.ts";
 import "./src/adapters/sqlite_test.ts";
 import "./src/adapters/postgres_test.ts";
 import "./src/adapters/mysql_test.ts";


### PR DESCRIPTION
We can use the same style as in the QueryBuilder to create a table.

+ Added addField({})
+ Changed Tests(for Table)
+ Changed Adapter to load a TableBuilder via tableBuilder()
+ Made Table to Masterobject to handle tables. (Which in turn will produce a TableBuilder which was previously Table)
+ Added Test to Table, Creating and Deleting a Test Table.
+ Added exists() and delete() to Table Object
+ Added size to ColumnDefinition instances. (I ran into errors when VARCHAR was undefined, could be something different, needs to be checked though)
+ Added Stubs for Info and Modify into Table