### PR TITLE
Bumped MySQL and Sqlite Deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.4.4
+FROM hayd/alpine-deno:1.5.2
 
 WORKDIR /app
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,10 +1,10 @@
-export { Client as MysqlClient } from "https://deno.land/x/mysql/mod.ts";
-export type { ClientConfig as MysqlClientConfig } from "https://deno.land/x/mysql/mod.ts";
+export { Client as MysqlClient } from "https://deno.land/x/mysql@v2.7.0/mod.ts";
+export type { ClientConfig as MysqlClientConfig } from "https://deno.land/x/mysql@v2.7.0/mod.ts";
 export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.4.5/mod.ts";
 export {
   DB as SqliteDB,
   Empty as SqliteEmpty,
-} from "https://deno.land/x/sqlite@v2.3.0/mod.ts";
+} from "https://deno.land/x/sqlite@v2.3.2/mod.ts";
 
 // CLI
 export * as Colors from "https://deno.land/std@0.74.0/fmt/colors.ts";


### PR DESCRIPTION
* MySQL has been bumped to address the `v` prefix deprecation bug.
* Sqlite has been bumped to take advantages upstream, see dyedgreen/deno-sqlite#94
  and dyedgreen/deno-sqlite#91.
* Bumped Dockerfile deno base from `1.4.4` to `1.5.2`, which is the latest available
  container at the time of this PR.