### PR TITLE
Upgrade postgres to v0.4.6

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export { Client as MysqlClient } from "https://deno.land/x/mysql@v2.7.0/mod.ts";
 export type { ClientConfig as MysqlClientConfig } from "https://deno.land/x/mysql@v2.7.0/mod.ts";
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.4.5/mod.ts";
+export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.4.6/mod.ts";
 export {
   DB as SqliteDB,
   Empty as SqliteEmpty,


### PR DESCRIPTION
Upgrade postgres to v0.4.6 to fix the error:
TS2345 [ERROR]: Argument of type 'T | undefined' is not assignable to parameter of type 'T | PromiseLike<T>'.
  Type 'undefined' is not assignable to type 'T | PromiseLike<T>'.
      resolve(value);
              ~~~~~
    at https://deno.land/x/postgres@v0.4.5/utils.ts:94:15