### PR TITLE
fix: reflect error

### DIFF
--- a/src/utils/reflect.ts
+++ b/src/utils/reflect.ts
@@ -1,3 +1,4 @@
+// Copied from https://github.com/rbuckton/reflect-metadata/blob/master/Reflect.ts
 /*! *****************************************************************************
 Copyright (C) Microsoft. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -740,12 +741,12 @@ export namespace Reflect {
     // feature test for Symbol support
     const supportsSymbol = typeof Symbol === "function";
     const toPrimitiveSymbol =
-      supportsSymbol && typeof Symbol.toPrimitive !== "undefined"
-        ? Symbol.toPrimitive
+      supportsSymbol && typeof (Symbol as any).toPrimitive !== "undefined"
+        ? (Symbol as any).toPrimitive
         : "@@toPrimitive";
     const iteratorSymbol =
-      supportsSymbol && typeof Symbol.iterator !== "undefined"
-        ? Symbol.iterator
+      supportsSymbol && typeof (Symbol as any).iterator !== "undefined"
+        ? (Symbol as any).iterator
         : "@@iterator";
     const supportsCreate = typeof Object.create === "function"; // feature test for Object.create support
     const supportsProto = { __proto__: [] } instanceof Array; // feature test for __proto__ support


### PR DESCRIPTION
There is a `Property 'toPrimitive' does not exist on type 'never'.` error when importing with deno 1.14.0

This fixes the error